### PR TITLE
Fix build issues with buildx > 0.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ LABEL maintainer="thespad"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
+    alpine-release \
     btrfs-progs \
     docker \
     docker-cli-buildx \
     docker-cli-compose \
     e2fsprogs \
     e2fsprogs-extra \
+    erofs-utils \
     git \
     ip6tables \
     iptables \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ARG BUILD_AGENT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thespad"
 
+ENV HOME=/config
+
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,12 +12,14 @@ LABEL maintainer="thespad"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
+    alpine-release \
     btrfs-progs \
     docker \
     docker-cli-buildx \
     docker-cli-compose \
     e2fsprogs \
     e2fsprogs-extra \
+    erofs-utils \
     git \
     ip6tables \
     iptables \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -9,6 +9,8 @@ ARG BUILD_AGENT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thespad"
 
+ENV HOME=/config
+
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -12,12 +12,14 @@ LABEL maintainer="thespad"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
+    alpine-release \
     btrfs-progs \
     docker \
     docker-cli-buildx \
     docker-cli-compose \
     e2fsprogs \
     e2fsprogs-extra \
+    erofs-utils \
     git \
     ip6tables \
     iptables \

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -9,6 +9,8 @@ ARG BUILD_AGENT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thespad"
 
+ENV HOME=/config
+
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \

--- a/root/etc/s6-overlay/s6-rc.d/init-build-agent-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-build-agent-config/run
@@ -104,8 +104,8 @@ if ! id -nG "$(id -nu "${PUID:-911}")" | grep -q "docker"; then
     usermod -aG docker "$(id -nu "${PUID:-911}")"
 fi
 
-HOME=/config git config --global user.email "ci@linuxserver.io"
-HOME=/config git config --global user.name "LinuxServer-CI"
+git config --global user.email "ci@linuxserver.io"
+git config --global user.name "LinuxServer-CI"
 
 # permissions
 lsiown -R "${USER_NAME}":"${USER_NAME}" \

--- a/root/etc/s6-overlay/s6-rc.d/init-build-agent-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-build-agent-config/run
@@ -107,24 +107,6 @@ fi
 HOME=/config git config --global user.email "ci@linuxserver.io"
 HOME=/config git config --global user.name "LinuxServer-CI"
 
-# Remove old Docker image store
-if [[ -d "/config/var/lib/docker/overlay2/" ]]; then
-    rm -rf "/config/var/lib/docker/overlay2/"
-fi
-
-if [[ -d "/config/var/lib/docker/image/" ]]; then
-    rm -rf "/config/var/lib/docker/image/"
-fi
-
-# Enable containerd image store
-cat <<EOF >/etc/docker/daemon.json
-{
-    "features": {
-        "containerd-snapshotter": true
-    }
-}
-EOF
-
 # permissions
 lsiown -R "${USER_NAME}":"${USER_NAME}" \
     /config

--- a/root/etc/s6-overlay/s6-rc.d/init-buildx-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-buildx-config/run
@@ -2,8 +2,8 @@
 # shellcheck shell=bash
 
 docker pull docker.io/moby/buildkit:buildx-stable-1
-HOME=/config docker buildx rm container >/dev/null 2>&1
-HOME=/config docker buildx create --driver docker-container --name container --bootstrap >/dev/null 2>&1
+docker buildx rm container >/dev/null 2>&1
+docker buildx create --driver docker-container --name container --bootstrap >/dev/null 2>&1
 docker image prune -f >/dev/null 2>&1
 
 USER_NAME=${USER_NAME:-jenkins}

--- a/root/etc/s6-overlay/s6-rc.d/init-qemu/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-qemu/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 echo "┌─────────────────────────────────────────────────────────────────────────────────┐"
-echo "│                   Make sure you enable you enable QEMU. Run:                    │"
+echo "│                         Make sure you enable QEMU. Run:                         │"
 echo "│                                                                                 │"
 echo "│ docker run --rm -it --privileged ghcr.io/linuxserver/qemu-static --reset -p yes │"
 echo "│                                                                                 │"

--- a/root/etc/s6-overlay/s6-rc.d/svc-docker-in-docker/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-docker-in-docker/run
@@ -32,4 +32,4 @@ mount --make-rshared /
 
 exec 2>&1 \
     s6-notifyoncheck -d -n 300 -w 1000 -c "docker version" \
-    /usr/bin/dockerd --data-root "/config/var/lib/docker" --experimental
+    /usr/bin/dockerd --data-root "/config/var/lib/docker"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-build-agent/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
http2 frame size error is definitely a red herring caused by the way it handles connection upgrades, the real issue seems to be that we were setting HOME only for specific commands (and passing as the docker data dir) and buildx has changed something about how it handles that and dies, but only when trying to handle the container builder, and not the default docker one.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
